### PR TITLE
Parse score to int before submitting

### DIFF
--- a/front-end/src/Forms/DoublesForm.js
+++ b/front-end/src/Forms/DoublesForm.js
@@ -64,7 +64,7 @@ const DoublesForm = () => {
     function handleMatchDataChange(evt) {
         if (evt.target.name == 'score') {
             let localObj = matchObj;
-            localObj.score[evt.target.id] = evt.target.value;
+            localObj.score[evt.target.id] = parseInt(evt.target.value);
             setMatchObj(localObj);
         }
         else {

--- a/front-end/src/Forms/MixedForm.js
+++ b/front-end/src/Forms/MixedForm.js
@@ -63,7 +63,7 @@ const MixedForm = () => {
     function handleMatchDataChange(evt) {
         if (evt.target.name == 'score') {
             let localObj = matchObj;
-            localObj.score[evt.target.id] = evt.target.value;
+            localObj.score[evt.target.id] = parseInt(evt.target.value);
             setMatchObj(localObj);
         }
         else {

--- a/front-end/src/Forms/SinglesForm.js
+++ b/front-end/src/Forms/SinglesForm.js
@@ -62,7 +62,7 @@ const SinglesForm = (formRef) => {
     function handleMatchDataChange(evt) {
         if (evt.target.name == 'score') {
             let localObj = matchObj;
-            localObj.score[evt.target.id] = evt.target.value;
+            localObj.score[evt.target.id] = parseInt(evt.target.value);
             setMatchObj(localObj);
         }
         else {


### PR DESCRIPTION
Make sure to submit an int to the API for scores, otherwise the backend does string comparisons instead which is bad since "21" < "3" in string comparisons.