### PR TITLE
Fix front end querying all api endpoints on page nav

### DIFF
--- a/front-end/src/components/Header.js
+++ b/front-end/src/components/Header.js
@@ -1,29 +1,35 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom'
 import { Col, Container, Nav, Navbar, Row, Offcanvas } from 'react-bootstrap'
 import { DropdownIcon } from '../icons/MainDropdown.js';
 import '../index.css'
 
 const Header = () => {
+    const [expanded, setExpanded] = useState(false);
+
     return (
         <>
             <Navbar fixed="sticky" className='header-panel' expand={false}>
                 <Container fluid>
                     <Navbar.Brand href="/" className='header'>WATERLOO WARRIORS</Navbar.Brand>
-                    <Navbar.Toggle aria-controls="offcanvasNavbar" />
+                    <Navbar.Toggle aria-controls="offcanvasNavbar" onClick={ () => setExpanded(!expanded) } />
                     <Navbar.Offcanvas
                         id="offcanvasNavbar"
                         aria-labelledby="offcanvasNavbarLabel"
                         placement="end"
+                        show={expanded}
                     >
                         <Offcanvas.Header closeButton>
                             <Offcanvas.Title id="offcanvasNavbarLabel">WARRIORS</Offcanvas.Title>
                         </Offcanvas.Header>
                         <Offcanvas.Body>
                             <Nav className="justify-content-end flex-grow-1 page-header pe-3">
-                                <Nav.Link href="/">HOME</Nav.Link>
-                                <Nav.Link href="/report">REPORT MATCH</Nav.Link>
-                                <Nav.Link href="/results">RESULTS</Nav.Link>
-                                <Nav.Link href="/elo">ELO RANKINGS</Nav.Link>
-                                <Nav.Link href="/admin">ADMIN</Nav.Link>
+                                <Nav.Link as={Link} to="/" onClick={ () => setExpanded(false) }>HOME</Nav.Link>
+                                <Nav.Link as={Link} to="/report" onClick={ () => setExpanded(false) }>REPORT MATCH</Nav.Link>
+                                <Nav.Link as={Link} to="/results" onClick={ () => setExpanded(false) }>RESULTS</Nav.Link>
+                                <Nav.Link as={Link} to="/elo" onClick={ () => setExpanded(false) }>ELO RANKINGS</Nav.Link>
+                                <Nav.Link as={Link} to="/admin" onClick={ () => setExpanded(false) }>ADMIN</Nav.Link>
+                                <Nav.Link as={Link} to="/players" onClick={ () => setExpanded(false) }>PLAYERS</Nav.Link>
                             </Nav>
                         </Offcanvas.Body>
                     </Navbar.Offcanvas>


### PR DESCRIPTION
Using href in the react nav link refreshes the entire page, use <Nav.Link to={Link} as="/path"> instead.